### PR TITLE
[ISSUE] Fix websocket connection close, fix websocket compression and permessage deflate factor parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Added
+
+- Added websocket close packet code and reason parsing
+
+### Fixed
+
+- Fixed clients not being destroyed on empty (close) frame received by router; clients are now marked as in exception state and deleted
+- Fixed client / server compression factor and permessage deflate value parsing
+
+
 ## [1.0.0] - 2018-11-01
 
 ### Added

--- a/src/zwssock/zwsdecoder.c
+++ b/src/zwssock/zwsdecoder.c
@@ -86,9 +86,9 @@ void zwsdecoder_process_buffer(zwsdecoder_t* self, zframe_t* data) {
 	int buffer_length = zframe_size(data);
 
 	// printf("   - Processing buffer:");
-	for (int i = 0; i < buffer_length; i++) {
-		// printf(" %u, ", buffer[i]);
-	}
+	// for (int i = 0; i < buffer_length; i++) {
+	// 	printf(" %u, ", buffer[i]);
+	// }
 	// printf("\n");
 
 	int bytes_to_read;

--- a/src/zwssock/zwsdecoder.c
+++ b/src/zwssock/zwsdecoder.c
@@ -307,7 +307,7 @@ static state_t zwsdecoder_next_state(zwsdecoder_t* self) {
 }
 
 static void invoke_new_message(zwsdecoder_t* self) {
-	// printf("Decoding new message - op: %u\n", self->opcode);
+	printf("Decoding new message - opcode: %u\n", self->opcode);
 	switch (self->opcode) {
 		case opcode_binary:
 			self->message_cb(self->tag, self->payload, self->payload_length);

--- a/src/zwssock/zwsdecoder.c
+++ b/src/zwssock/zwsdecoder.c
@@ -85,11 +85,11 @@ void zwsdecoder_process_buffer(zwsdecoder_t* self, zframe_t* data) {
 	byte* buffer = zframe_data(data);
 	int buffer_length = zframe_size(data);
 
-	printf("   - Processing buffer:");
+	// printf("   - Processing buffer:");
 	for (int i = 0; i < buffer_length; i++) {
-		printf(" %u, ", buffer[i]);
+		// printf(" %u, ", buffer[i]);
 	}
-	printf("\n");
+	// printf("\n");
 
 	int bytes_to_read;
 
@@ -153,7 +153,7 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 
 			// not final messages are currently not supported
 			if (!final) {
-				printf("Decoder: unsupported FINAL\n");
+				// printf("Decoder: unsupported FINAL\n");
 				self->state = STATE_ERROR;
 
 			// Check that the opcode is supported
@@ -161,7 +161,7 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 						&& self->opcode != opcode_close
 						&& self->opcode != opcode_ping
 						&& self->opcode != opcode_pong) {
-				printf("Decoder: unsupported OP code\n");
+				// printf("Decoder: unsupported OP code\n");
 				self->state = STATE_ERROR;
 			} else {
 				self->state = STATE_SECOND_BYTE;
@@ -219,7 +219,7 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 
 			// must be zero, max message size is MaxInt
 			if (b != 0) {
-				printf("Decoder: message size exceeded max (MaxInt)\n");
+				// printf("Decoder: message size exceeded max (MaxInt)\n");
 				self->state = STATE_ERROR;
 			}
 			else
@@ -230,7 +230,7 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 		case STATE_LONG_SIZE_2:
 			// must be zero, max message size is MaxInt
 			if (b != 0) {
-				printf("Decoder: message size exceeded max (MaxInt)\n");
+				// printf("Decoder: message size exceeded max (MaxInt)\n");
 				self->state = STATE_ERROR;
 			}
 			else
@@ -240,7 +240,7 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 		case STATE_LONG_SIZE_3:
 			// must be zero, max message size is MaxInt
 			if (b != 0) {
-				printf("Decoder: message size exceeded max (MaxInt)\n");
+				// printf("Decoder: message size exceeded max (MaxInt)\n");
 				self->state = STATE_ERROR;
 			}
 			else
@@ -250,7 +250,7 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 		case STATE_LONG_SIZE_4:
 			// must be zero, max message size is MaxInt
 			if (b != 0) {
-				printf("Decoder: message size exceeded max (MaxInt)\n");
+				// printf("Decoder: message size exceeded max (MaxInt)\n");
 				self->state = STATE_ERROR;
 			}
 			else
@@ -284,7 +284,7 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 			break;
 
 		case STATE_ERROR:
-			printf("Decoder: error encountered...\n");
+			// printf("Decoder: error encountered...\n");
 			// UNIMPLEMENTED
 			break;
 	}
@@ -307,7 +307,7 @@ static state_t zwsdecoder_next_state(zwsdecoder_t* self) {
 }
 
 static void invoke_new_message(zwsdecoder_t* self) {
-	printf("Decoding new message - op: %u\n", self->opcode);
+	// printf("Decoding new message - op: %u\n", self->opcode);
 	switch (self->opcode) {
 		case opcode_binary:
 			self->message_cb(self->tag, self->payload, self->payload_length);

--- a/src/zwssock/zwsdecoder.c
+++ b/src/zwssock/zwsdecoder.c
@@ -307,7 +307,6 @@ static state_t zwsdecoder_next_state(zwsdecoder_t* self) {
 }
 
 static void invoke_new_message(zwsdecoder_t* self) {
-	printf("Decoding new message - opcode: %u\n", self->opcode);
 	switch (self->opcode) {
 		case opcode_binary:
 			self->message_cb(self->tag, self->payload, self->payload_length);

--- a/src/zwssock/zwsdecoder.c
+++ b/src/zwssock/zwsdecoder.c
@@ -1,5 +1,6 @@
 #include "zwsdecoder.h"
 
+
 typedef enum {
 	opcode_continuation		= 0,
 	opcode_text 					= 0x01,
@@ -49,10 +50,12 @@ struct _zwsdecoder_t {
 	pong_callback_t pong_cb;
 };
 
+
 // Private methods
 static void invoke_new_message(zwsdecoder_t* self);
 static state_t zwsdecoder_next_state(zwsdecoder_t* self);
 static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b);
+
 
 zwsdecoder_t* zwsdecoder_new(
 		void* tag,
@@ -84,13 +87,6 @@ void zwsdecoder_process_buffer(zwsdecoder_t* self, zframe_t* data) {
 
 	byte* buffer = zframe_data(data);
 	int buffer_length = zframe_size(data);
-
-	// printf("   - Processing buffer:");
-	// for (int i = 0; i < buffer_length; i++) {
-	// 	printf(" %u, ", buffer[i]);
-	// }
-	// printf("\n");
-
 	int bytes_to_read;
 
 	while (i < buffer_length) {
@@ -153,7 +149,6 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 
 			// not final messages are currently not supported
 			if (!final) {
-				// printf("Decoder: unsupported FINAL\n");
 				self->state = STATE_ERROR;
 
 			// Check that the opcode is supported
@@ -161,7 +156,6 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 						&& self->opcode != opcode_close
 						&& self->opcode != opcode_ping
 						&& self->opcode != opcode_pong) {
-				// printf("Decoder: unsupported OP code\n");
 				self->state = STATE_ERROR;
 			} else {
 				self->state = STATE_SECOND_BYTE;
@@ -219,7 +213,6 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 
 			// must be zero, max message size is MaxInt
 			if (b != 0) {
-				// printf("Decoder: message size exceeded max (MaxInt)\n");
 				self->state = STATE_ERROR;
 			}
 			else
@@ -230,7 +223,6 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 		case STATE_LONG_SIZE_2:
 			// must be zero, max message size is MaxInt
 			if (b != 0) {
-				// printf("Decoder: message size exceeded max (MaxInt)\n");
 				self->state = STATE_ERROR;
 			}
 			else
@@ -240,7 +232,6 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 		case STATE_LONG_SIZE_3:
 			// must be zero, max message size is MaxInt
 			if (b != 0) {
-				// printf("Decoder: message size exceeded max (MaxInt)\n");
 				self->state = STATE_ERROR;
 			}
 			else
@@ -250,7 +241,6 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 		case STATE_LONG_SIZE_4:
 			// must be zero, max message size is MaxInt
 			if (b != 0) {
-				// printf("Decoder: message size exceeded max (MaxInt)\n");
 				self->state = STATE_ERROR;
 			}
 			else
@@ -284,7 +274,6 @@ static void zwsdecoder_process_byte(zwsdecoder_t* self, byte b) {
 			break;
 
 		case STATE_ERROR:
-			// printf("Decoder: error encountered...\n");
 			// UNIMPLEMENTED
 			break;
 	}

--- a/src/zwssock/zwshandshake.c
+++ b/src/zwssock/zwshandshake.c
@@ -384,26 +384,26 @@ zframe_t* zwshandshake_get_response(zwshandshake_t* self, unsigned char* client_
 			ZWS_LOG_DEBUG((" - Client compression factor...\n"));
 
 			if (client_factor != NULL) {
-				ZWS_LOG_DEBUG(("   - Specified (true)\n"));
 				extension_client_compression_factor = true;
+				ZWS_LOG_DEBUG(("   - Value specified (defaulting to previous, %i)\n", *client_compression_factor));
 			} else {
-				ZWS_LOG_DEBUG(("   - Not specified: (defaulting to 15)\n"));
 				*client_compression_factor = 15;
+				ZWS_LOG_DEBUG(("   - Value not specified: (defaulting to 15)\n"));
 			}
 
-			ZWS_LOG_DEBUG((" - Client max bits...\n"));
+			ZWS_LOG_DEBUG((" - Client max window bits...\n"));
 			if (client_max_bits != NULL) {
 				char* client_bits_specified = strstr(key_extensions, "client_max_window_bits=");
 
 				if (client_bits_specified) {
 					extension_client_compression_factor = true;
 					*client_compression_factor = 15;
-					ZWS_LOG_DEBUG(("   - Specified (defaulting to 15)\n"));
+					ZWS_LOG_DEBUG(("   - Value specified (defaulting to 15)\n"));
 
 				} else {
-					ZWS_LOG_DEBUG(("   - Specified as 0\n"));
 					extension_client_compression_factor = false;
 					*client_compression_factor = 0;
+					ZWS_LOG_DEBUG(("   - Value not specified (defaulting to 0)\n"));
 				}
 			} else {
 				*client_compression_factor = 15;
@@ -415,7 +415,6 @@ zframe_t* zwshandshake_get_response(zwshandshake_t* self, unsigned char* client_
 			char* factor_str = strstr(key_extensions, "server_compression_factor=");
 			if (factor_str) {
 				extension_server_compression_factor = true;
-				ZWS_LOG_DEBUG(("   - Specified\n", *server_compression_factor));
 
 				long int server_compression_factor_candidate = strtol(factor_str + sizeof("server_compression_factor="), NULL, 10);
 
@@ -425,10 +424,10 @@ zframe_t* zwshandshake_get_response(zwshandshake_t* self, unsigned char* client_
 				} else {
 					*server_compression_factor = server_compression_factor_candidate;
 				}
-				ZWS_LOG_DEBUG(("   	- Value: (%i)\n", *server_compression_factor));
+				ZWS_LOG_DEBUG(("   - Value specified (%i)\n", *server_compression_factor));
 
 			} else {
-				ZWS_LOG_DEBUG(("   - Not specified (false)\n", *server_compression_factor));
+				ZWS_LOG_DEBUG(("   - Value not specified (defaulting to previous, %i)\n", *server_compression_factor));
 				extension_server_compression_factor = false;
 			}
 		} else {

--- a/src/zwssock/zwshandshake.c
+++ b/src/zwssock/zwshandshake.c
@@ -263,7 +263,7 @@ bool zwshandshake_parse_request(zwshandshake_t* self, zframe_t* data) {
 			if (c == '\n')
 			{
 				self->state = complete;
-				printf("Handshake:\n\"%s\"\n", request);
+				// printf("Handshake:\n\"%s\"\n", request);
 				free(request);
 				return zwshandshake_validate(self);
 			}
@@ -380,7 +380,7 @@ zframe_t* zwshandshake_get_response(zwshandshake_t* self, unsigned char* client_
 			if (client_factor != NULL) {
 				extension_client_compression_factor = true;
 				*client_compression_factor = 15;
-				printf("   - specified (default to 15)\n");
+				printf("   - Specified (default to 15)\n");
 
 			} else if (client_max_bits != NULL) {
 				char* client_bits_specified = strstr(key_extensions, "client_max_window_bits=");
@@ -388,16 +388,17 @@ zframe_t* zwshandshake_get_response(zwshandshake_t* self, unsigned char* client_
 				if (client_bits_specified) {
 					extension_client_compression_factor = true;
 					*client_compression_factor = 15;
-					printf("   - specified (default to 15)\n");
+					printf("   - Specified (default to 15)\n");
 
 				} else {
-					printf("   - not specified");
-					extension_client_compression_factor = false;
+					printf("   - Specified as 0");
+					extension_client_compression_factor = true;
+					*client_compression_factor = 0;
 				}
 			} else {
 				extension_client_compression_factor = true;
 				*client_compression_factor = 15;
-				printf("   - not specified (default to 15)\n");
+				printf("   - Not specified (default to 15)\n");
 			}
 			printf("\n");
 

--- a/src/zwssock/zwshandshake.c
+++ b/src/zwssock/zwshandshake.c
@@ -270,17 +270,17 @@ bool zwshandshake_parse_request(zwshandshake_t* self, zframe_t* data) {
 			break;
 		case error:
 			free(request);
-			printf("Handshake error\n");
+			// printf("Handshake error\n");
 			return false;
 		default:
-			printf("Handshake default\n");
+			// printf("Handshake default\n");
 			assert(false);
 			free(request);
 			return false;
 		}
 	}
-	printf("Invalid handshake\n");
-	printf("\"%s\"\n", request);
+	// printf("Invalid handshake\n");
+	// printf("\"%s\"\n", request);
 
 	free(request);
 	return false;
@@ -362,17 +362,17 @@ zframe_t* zwshandshake_get_response(zwshandshake_t* self, unsigned char* client_
 	bool extension_server_compression_factor = false;
 
 	char* key_extensions = zhash_lookup(self->header_fields, sec_websocket_extensions_name);
-	printf("Parsing WebSocket extensions...\n");
+	// printf("Parsing WebSocket extensions...\n");
 	if (key_extensions) {
-		printf(" - Specified\n");
-		printf(" - Extensions: %s\n", key_extensions);
+		// printf(" - Specified\n");
+		// printf(" - Extensions: %s\n", key_extensions);
 
 		if(strstr(key_extensions, "permessage-deflate") != NULL &&
 				*client_compression_factor > 0 && *server_compression_factor > 0) {
-			printf(" - Per-message deflate specified...\n");
+			// printf(" - Per-message deflate specified...\n");
 
 			// Parse client compression factor
-			printf(" - Client compression factor...\n");
+			// printf(" - Client compression factor...\n");
 			extension_permessage_deflate = true;
 			char* client_factor = strstr(key_extensions, "client_compression_factor");
 			char* client_max_bits = strstr(key_extensions, "client_max_window_bits");
@@ -380,7 +380,7 @@ zframe_t* zwshandshake_get_response(zwshandshake_t* self, unsigned char* client_
 			if (client_factor != NULL) {
 				extension_client_compression_factor = true;
 				*client_compression_factor = 15;
-				printf("   - Specified (default to 15)\n");
+				// printf("   - Specified (default to 15)\n");
 
 			} else if (client_max_bits != NULL) {
 				char* client_bits_specified = strstr(key_extensions, "client_max_window_bits=");
@@ -388,22 +388,22 @@ zframe_t* zwshandshake_get_response(zwshandshake_t* self, unsigned char* client_
 				if (client_bits_specified) {
 					extension_client_compression_factor = true;
 					*client_compression_factor = 15;
-					printf("   - Specified (default to 15)\n");
+					// printf("   - Specified (default to 15)\n");
 
 				} else {
-					printf("   - Specified as 0");
+					// printf("   - Specified as 0");
 					extension_client_compression_factor = false;
 					*client_compression_factor = 0;
 				}
 			} else {
 				extension_client_compression_factor = true;
 				*client_compression_factor = 15;
-				printf("   - Not specified (default to 15)\n");
+				// printf("   - Not specified (default to 15)\n");
 			}
-			printf("\n");
+			// printf("\n");
 
 			// Parse server compression factor
-			printf(" - Server compression factor...\n");
+			// printf(" - Server compression factor...\n");
 			char* factor_str = strstr(key_extensions, "server_compression_factor=");
 			if (factor_str) {
 				extension_server_compression_factor = true;
@@ -414,14 +414,14 @@ zframe_t* zwshandshake_get_response(zwshandshake_t* self, unsigned char* client_
 				if (server_compression_factor_candidate >= 8 || server_compression_factor_candidate <= 15) {
 					*server_compression_factor = (unsigned char) (server_compression_factor_candidate & 15);
 				}
-				printf("   - Specified (%i)\n", *server_compression_factor);
+				// printf("   - Specified (%i)\n", *server_compression_factor);
 
 			} else {
 				*server_compression_factor = 0;
-				printf("   - Not specified (default to %i)\n", *server_compression_factor);
+				// printf("   - Not specified (default to %i)\n", *server_compression_factor);
 			}
 		} else {
-			printf("   - Not specified\n");
+			// printf("   - Not specified\n");
 			*client_compression_factor = 0;
 			*server_compression_factor = 0;
 		}  // end if (strstr(key_extensions, "permessage-deflate") != NULL)

--- a/src/zwssock/zwshandshake.c
+++ b/src/zwssock/zwshandshake.c
@@ -392,7 +392,7 @@ zframe_t* zwshandshake_get_response(zwshandshake_t* self, unsigned char* client_
 
 				} else {
 					printf("   - Specified as 0");
-					extension_client_compression_factor = true;
+					extension_client_compression_factor = false;
 					*client_compression_factor = 0;
 				}
 			} else {

--- a/src/zwssock/zwssock.c
+++ b/src/zwssock/zwssock.c
@@ -365,6 +365,7 @@ void websocket_close_received(void* tag, byte* payload, int length) {
 		send_close_frame(self->agent->stream);
 		send_empty_frame(self->agent->stream);
 	} else {
+		send_close_frame(self->agent->stream);
 		send_empty_frame(self->agent->stream);
 	}
 }
@@ -440,9 +441,10 @@ static void client_data_read(client_t* self) {
 					free(response);
 
 					if (self->client_compression_factor > 0) {
+						printf("Inflating data with client compression factor %i\n", self->client_compression_factor);
 						int ret = inflateInit2(&self->permessage_deflate_client, -self->client_compression_factor);
 						if (ret != Z_OK) {
-							printf("EXCEPTION: Could not inflate; connection error\n");
+							printf("EXCEPTION: Could not inflate; (%i)\n", ret);
 							self->client_compression_factor = 0;
 							self->state = CONNECTION_EXCEPTION;
 							not_acceptable(self->address, self->agent->stream);
@@ -450,7 +452,7 @@ static void client_data_read(client_t* self) {
 
 						ret = deflateInit2(&self->permessage_deflate_server, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -self->server_compression_factor, 8, Z_DEFAULT_STRATEGY);
 						if (ret != Z_OK) {
-							printf("EXCEPTION: Could not deflate; connection error\n");
+							printf("EXCEPTION: Could not deflate; (%i)\n", ret);
 							self->server_compression_factor = 0;
 							self->state = CONNECTION_EXCEPTION;
 							not_acceptable(self->address, self->agent->stream);

--- a/src/zwssock/zwssock.c
+++ b/src/zwssock/zwssock.c
@@ -327,22 +327,6 @@ void zwssock_router_message_received(void* tag, byte* payload, int length) {
 }
 
 /**
- * Send an empty ZeroMQ frame
- *
- * Used for closing ZMQ_STREAM sockets
-*/
-void send_close_frame(void* tag) {
-	uint8_t op = 8;
-	client_t* self = (client_t*)tag;
-	zframe_t* address = zframe_dup(self->address);
-	zframe_t* close = zframe_new(&op, 1);
-
-	zframe_send(&address, self->agent->stream, ZFRAME_MORE);
-	zframe_send(&close, self->agent->stream, 0);
-	ZWS_LOG_DEBUG((" - Sent close frame to endpoint [%s] (%s)\n", self->hashkey, zsock_endpoint(self->agent->stream)));
-}
-
-/**
  * Send a websocket close frame
 */
 void send_empty_frame(void* tag) {
@@ -361,8 +345,8 @@ void websocket_close(void* tag) {
 
 	ZWS_LOG_DEBUG(("Closing WebSocket endpoint [%s] (%s)\n", self->hashkey, zsock_endpoint(self->agent->stream)));
 
-	// send_close_frame(self);
 	send_empty_frame(self);
+	self->state = CONNECTION_EXCEPTION;
 }
 
 /**

--- a/src/zwssock/zwssock.c
+++ b/src/zwssock/zwssock.c
@@ -377,19 +377,19 @@ void websocket_close_received(void* tag, byte* payload, int length) {
 	// First two bytes are a 2 byte unsigned int, code
 	if (length >= 2) {
 		code = payload[1] | (uint16_t)payload[0] << 8;  // Network order; big endian
+		length = length - 2;
 		// Remaining bytes is a UTF-8 encoded string, reason
 		if (length > 2) {
-
 			reason = malloc(sizeof(char) * (length - 2));
-			memcpy(reason, payload + 2, length-2);
+			memcpy(reason, payload + 2, length - 2);
 		}
 	}
 
 	ZWS_LOG_DEBUG(("WebSocket close frame received from endpoint [%s] (%s)\n", self->hashkey, zsock_endpoint(self->agent->stream)));
 	if (length >= 2)
 		ZWS_LOG_DEBUG((" - code: %u\n", code));
-	if (reason != NULL)
-		ZWS_LOG_DEBUG((" - reason: (%u) \"%s\"\n", length - 2, reason));
+	if (length > 2)
+		ZWS_LOG_DEBUG((" - reason: \"%s\"\n", reason));
 	
 	websocket_close(tag);
 }
@@ -442,8 +442,6 @@ static void not_acceptable(zframe_t *_address, void* dest) {
 static void client_data_read(client_t* self) {
 	zframe_t* data;
 	zwshandshake_t* handshake;
-
-	ZWS_LOG_DEBUG((" - Reading data from endpoint [%s] (%s), state: %i\n", self->hashkey, zsock_endpoint(self->agent->stream), self->state));
 
 	data = zframe_recv(self->agent->stream);
 

--- a/src/zwssock/zwssock.c
+++ b/src/zwssock/zwssock.c
@@ -306,7 +306,7 @@ void zwssock_router_message_received(void* tag, byte* payload, int length) {
 
 	// No decompression needed
 	} else {
-		printf("   - No decompression needed for client data, proceeding...");
+		printf("   - No decompression needed for client data, proceeding...\n");
 		message_continued = (payload[0] == 1);
 		zmsg_addmem(self->outgoing_msg, &payload[1], length - 1);
 	}
@@ -363,10 +363,10 @@ void websocket_close_received(void* tag, byte* payload, int length) {
 
 	if (code == 1000) {
 		send_close_frame(self->agent->stream);
-		send_empty_frame(self->agent->stream);
+		// send_empty_frame(self->agent->stream);
 	} else {
 		send_close_frame(self->agent->stream);
-		send_empty_frame(self->agent->stream);
+		// send_empty_frame(self->agent->stream);
 	}
 }
 

--- a/test/c_test.c
+++ b/test/c_test.c
@@ -93,6 +93,7 @@ int main(int argc, char** argv) {
 		// zmsg_addmem(res, &double_pos, sizeof(double_pos));
 		// zmsg_addmem(res, &double_neg, sizeof(double_neg));
 
+		printf("Sending message back to client...\n");
 		int rc = zwssock_send(sock, &res);
 		if (rc != 0) {
 			zmsg_destroy(&res);


### PR DESCRIPTION
### Added
- Added websocket close packet code and reason parsing

### Fixed

- Fixed clients not being destroyed on empty (close) frame received by router; clients are now marked as in exception state and deleted
- Fixed client / server compression factor and permessage deflate value parsing